### PR TITLE
Modified backend/imageverify/server.js to lower the matching threshol…

### DIFF
--- a/backend/imageverify/server.js
+++ b/backend/imageverify/server.js
@@ -61,9 +61,11 @@ app.post('/verify', upload.fields([{ name: 'storedImage', maxCount: 1 }, { name:
 
         const distance = faceapi.euclideanDistance(storedDetection.descriptor, capturedDetection.descriptor);
         
-        // Threshold is usually 0.6
-        const threshold = 0.6;
+        // Threshold is usually 0.6, but lowering to 0.4 for stricter security
+        const threshold = 0.4;
         const isMatch = distance < threshold;
+
+        console.log(`Verification result: Distance = ${distance}, Threshold = ${threshold}, Match = ${isMatch}`);
 
         res.json({ match: isMatch, distance: distance });
 

--- a/backend/onlinevotingsystem/pom.xml
+++ b/backend/onlinevotingsystem/pom.xml
@@ -50,6 +50,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-websocket</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
 
 		<!-- JWT Dependencies -->
 		<dependency>


### PR DESCRIPTION
…d from 0.6 to 0.4

Solved #18 

This ensures that faces must be a much closer match to the profile picture to pass. Using a friend's photo or
         wearing a mask (which changes facial features) will now result in a significantly higher "distance" score,
         causing the verification to correctly fail.

   2. Improved Error Messages:
       * Updated VoteService.java in the backend to properly handle error responses from the verification server.
       * Instead of a generic "400 Bad Request" error, the system will now display the specific reason (e.g., "No face
         detected in captured image") to the user.

   3. Build Fixes:
       * Added jackson-databind to backend/onlinevotingsystem/pom.xml to support the new error parsing logic and
         successfully compiled the Java backend.